### PR TITLE
Add react-query for data fetching and refactor components

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
 		"preview": "node_modules/.bin/vite preview"
 	},
 	"dependencies": {
+		"@tanstack/react-query": "^5.62.10",
 		"@vercel/node": "^5.0.0",
 		"axios": "^1.6.7",
 		"escape-html": "^1.0.3",

--- a/src/components/projects.tsx
+++ b/src/components/projects.tsx
@@ -53,6 +53,7 @@ const Projects = (props) => {
         <div class={"projects__grid"}>
             <div id={"brief"} className={"brief"}>
                 {page.map((p, index) => {
+                    console.log(p)
                     return (
                         <section>
                             <div>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,17 +1,21 @@
 import { LocationProvider, Route , Router, hydrate, prerender as ssr } from 'preact-iso';
 import { h } from 'preact';
-
+import {QueryClient, QueryClientProvider} from "@tanstack/react-query";
 import {Home} from "./pages/home";
 import {Project} from "./pages/project";
 
+const queryClient = new QueryClient();
+
 function App({url}:{url:string})  {
     return(
-        <LocationProvider>
-            <Router>
-                <Route path="/" component={Home} />
-                <Route path="/project/:id?" component={Project} />
-            </Router>
-        </LocationProvider>
+        <QueryClientProvider client={queryClient}>
+            <LocationProvider>
+                <Router>
+                    <Route path="/" component={Home} />
+                    <Route path="/project/:id?" component={Project} />
+                </Router>
+            </LocationProvider>
+        </QueryClientProvider>
     )
 }
 
@@ -22,7 +26,13 @@ if (typeof window !== 'undefined') {
 }
 
 export async function prerender(data) {
-    const html = ssr(<App url={data.url} />);
+    // SSR
+    const html = ssr(
+        <QueryClientProvider client={queryClient}>
+            <App url={data.url} />
+        </QueryClientProvider>
+    );
+    // HTML
     return {
         html,
         head: {

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -9,7 +9,7 @@ import Pillar from "../sketches/pillar";
 import Resume from "../components/resume";
 import {useState} from "preact/hooks";
 import {useEffect} from "preact/hooks";
-import {fetchPayload} from "../utils/fetchPayload";
+import {fetchPayload, useCachedPayload} from "../utils/fetchPayload";
 import serialize from "../utils/serialize";
 import Projects from "../components/projects";
 import CalculateSize from "../components/fetchSize";
@@ -21,29 +21,27 @@ export function Home() {
 	const [type, setType] = useState("home")
 	const [menuOpen, setMenuOpen] = useState(false)
 	const [scrollToID, setScrollToID] = useState(null)
-
-	const [resume, setResume] = useState([])
-	const [music, setMusic] = useState([])
-	const [about, setAbout] = useState([])
-	const [pages, setPages] = useState([])
-	const [globals, setGlobals] = useState([])
 	const [var1, setVar1] = useState(Math.floor(Math.random() * 10))
+	let about = []
 
-	useEffect(() => {
-		fetchPayload("https://p01--admin--cvvgvqwlxhx2.code.run", "about", 10).then((data)=>{
-			setGlobals(data.docs)
-			setAbout(serialize(data.docs[0]["bio"]))
-		})
-		fetchPayload("https://p01--admin--cvvgvqwlxhx2.code.run", "page", 10).then((data)=>{
-			setPages(data.docs)
-		})
-		fetchPayload("https://p01--admin--cvvgvqwlxhx2.code.run", "music", 10).then((data)=>{
-			setMusic(data.docs)
-		})
-		fetchPayload("https://p01--admin--cvvgvqwlxhx2.code.run", "resume", 10).then((data)=>{
-			setResume(data.docs[0])
-		})
-	}, []);
+	// BASE_URI
+	// todo: move to env?
+	const BASE_URI = 'https://p01--admin--cvvgvqwlxhx2.code.run';
+
+	// fetch data
+	const { data: pagesData } = useCachedPayload(BASE_URI, "page", 10000);
+	const { data: musicData } = useCachedPayload(BASE_URI, "music", 10000);
+	const { data: resumeData } = useCachedPayload(BASE_URI, "resume", 10000);
+	const { data: aboutData } = useCachedPayload(BASE_URI, "about", 10000);
+
+	// derive states from the cached data.
+	const pages = pagesData?.docs || []
+	const music = musicData?.docs || []
+	const resume = resumeData?.docs[0] || []
+	const globals = aboutData?.docs || []
+	if (aboutData?.docs[0]["bio"]) {
+		about = serialize(aboutData?.docs[0]["bio"])
+	}
 
 	useEffect(() => {
 		cycle(); // Call cycle() when component mounts

--- a/src/utils/fetchPayload.ts
+++ b/src/utils/fetchPayload.ts
@@ -1,4 +1,6 @@
-export async function fetchPayload(BASE_URI, collection, limit) {
+import {useQuery} from "@tanstack/react-query";
+
+export async function fetchPayload(BASE_URI: string, collection: string, limit: number) {
     try{
         const res = await fetch(`${BASE_URI}/api/${collection}?limit=${limit}`)
         const data = await res.json()
@@ -6,4 +8,12 @@ export async function fetchPayload(BASE_URI, collection, limit) {
     } catch(e) {
         console.error(e)
     }
+}
+
+export function useCachedPayload(BASE_URI: string, collection: string, limit:number) {
+    return useQuery({
+        queryKey: ['fetchPayload', {collection, limit}],
+        queryFn: ()=> fetchPayload(BASE_URI, collection, limit),
+        staleTime: 1000 * 60 * 60 * 24,
+    })
 }


### PR DESCRIPTION
Integrated @tanstack/react-query for efficient caching and data fetching throughout the app. Refactored `fetchPayload` and related components to use `useQuery` hooks, ensuring cleaner state management. Updated `index.tsx` to wrap the app with `QueryClientProvider`.